### PR TITLE
Tag Remove Button improvements

### DIFF
--- a/src/jquery.tagsinput-revisited.css
+++ b/src/jquery.tagsinput-revisited.css
@@ -42,6 +42,7 @@
 	border: 0;
 	cursor: pointer;
 	font-size: 8px;
+	padding: 0;
 	position: absolute;
 	display: block;
 	width: 30px;

--- a/src/jquery.tagsinput-revisited.css
+++ b/src/jquery.tagsinput-revisited.css
@@ -37,39 +37,25 @@
 	margin: 0 5px 5px 0;
 }
 
-.tagsinput .tag a {
+.tagsinput .tag .tag-remove {
+	background: none;
+	border: 0;
+	cursor: pointer;
+	font-size: 8px;
 	position: absolute;
 	display: block;
 	width: 30px;
 	height: 30px;
 	top: 0;
 	right: 0;
-	text-decoration: none;
 	text-align: center;
 	color: #ff6b6b;
 	line-height: 30px;
 }
 
-.tagsinput .tag a:before,
-.tagsinput .tag a:after {
-	background: #ff6b6b;
-	position: absolute;
-	display: block;
-	width: 10px;
-	height: 2px;
-	top: 14px;
-	left: 10px;
-	content: '';
-}
-
-.tagsinput .tag a:before {
-	-webkit-transform: rotateZ(45deg);
-	transform: rotateZ(45deg);
-}
-
-.tagsinput .tag a:after {
-	-webkit-transform: rotateZ(-45deg);
-	transform: rotateZ(-45deg);
+.tagsinput .tag .tag-remove:before {
+	color: #ff6b6b;
+	content: '\2573'; /* (U+2573, BOX DRAWINGS LIGHT DIAGONAL CROSS) */
 }
 
 .tagsinput div {

--- a/src/jquery.tagsinput-revisited.css
+++ b/src/jquery.tagsinput-revisited.css
@@ -54,7 +54,6 @@
 }
 
 .tagsinput .tag .tag-remove:before {
-	color: #ff6b6b;
 	content: '\2573'; /* (U+2573, BOX DRAWINGS LIGHT DIAGONAL CROSS) */
 }
 

--- a/src/jquery.tagsinput-revisited.js
+++ b/src/jquery.tagsinput-revisited.js
@@ -27,7 +27,7 @@
 				return false;
 			}
 			
-			$('<span>').addClass('tag').append(
+			$('<span>', {class: 'tag'}).append(
 				$('<span>', {class: 'tag-text'}).text(value),
 				$('<button>', {class: 'tag-remove'}).click(function() {
 					return $('#' + id).removeTag(encodeURI(value));

--- a/src/jquery.tagsinput-revisited.js
+++ b/src/jquery.tagsinput-revisited.js
@@ -155,11 +155,11 @@
 				callbacks[id]['onChange'] = settings.onChange;
 			}
 
-			var markup = '<div id="' + id + '_tagsinput" class="tagsinput"><div id="' + id + '_addTag">';
-
-			if (settings.interactive) {
-				markup = markup + '<input id="' + id + '_tag" value="" placeholder="' + settings.placeholder + '">';
-			}
+			var markup = $('<div>', {id: id + '_tagsinput', class: 'tagsinput'}).append(
+				$('<div>', {id: id + '_addTag'}).append(
+					settings.interactive ? $('<input>', {id: id + '_tag', class: 'tag-input', value: '', placeholder: settings.placeholder}) : null
+				)
+			);
 
 			$(markup).insertAfter(this);
 

--- a/src/jquery.tagsinput-revisited.js
+++ b/src/jquery.tagsinput-revisited.js
@@ -28,7 +28,7 @@
 			}
 			
 			$('<span>').addClass('tag').append(
-				$('<span>').text(value),
+				$('<span>', {class: 'tag-text'}).text(value),
 				$('<button>', {class: 'tag-remove'}).click(function() {
 					return $('#' + id).removeTag(encodeURI(value));
 				})

--- a/src/jquery.tagsinput-revisited.js
+++ b/src/jquery.tagsinput-revisited.js
@@ -29,7 +29,7 @@
 			
 			$('<span>').addClass('tag').append(
 				$('<span>').text(value),
-				$('<a>', {href: '#'}).click(function() {
+				$('<button>', {class: 'tag-remove'}).click(function() {
 					return $('#' + id).removeTag(encodeURI(value));
 				})
 			).insertBefore('#' + id + '_addTag');


### PR DESCRIPTION
- Switches out the HTML-tag to a `<button>` instead of an `<a href="#">`
- Unify way of setting class attributes on dynamically created tags (pure cosmetics)
- Adapt styles to deal with the button element
- Improve usability by adding a pointer cursor on the button
- Reduce complexity of CSS by using a UTF-8 entity for the cross instead of :before/:after magic