### PR TITLE
Allow a space in pasted tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery.tagsinput-revisited",
-  "version": "2.1",
+  "version": "2.1.0",
   "description": "Revisited version of popular jQuery Tags Input Plugin",
   "main": "jquery.tagsinput-revisited",
   "directories": {

--- a/src/jquery.tagsinput-revisited.js
+++ b/src/jquery.tagsinput-revisited.js
@@ -249,7 +249,7 @@
 				var value = $(event.data.fake_input).val();
 				
 				value = value.replace(/\n/g, '');
-				value = value.replace(/\s/g, '');
+				value = value.replace(/\s/g, ' ');
 				
 				var tags = _splitIntoTags(event.data.delimiter, value);
 				


### PR DESCRIPTION
Currently after pasting a few words with spaces (for example: katalog stron, reklama strony www, reklama, indeks polskich stron), tags look like this: katalogstron, reklamastronywww, reklama, indekspolskichstron

I suggest replace spaces to one or remove line value = value.replace(/\s/g, '');