### PR TITLE
Prevent Undefined Tag Removals

### DIFF
--- a/src/jquery.tagsinput-revisited.js
+++ b/src/jquery.tagsinput-revisited.js
@@ -75,7 +75,7 @@
 			$('#' + id + '_tagsinput .tag').remove();
 			
 			var str = '';
-			for (i = 0; i < old.length; ++i) {
+			for (var i = 0; i < old.length; ++i) {
 				if (old[i] != value) {
 					str = str + _getDelimiter(delimiter[id]) + old[i];
 				}
@@ -299,7 +299,7 @@
 		var id = $(obj).attr('id');
 		var tags = _splitIntoTags(delimiter[id], val); 
 		
-		for (i = 0; i < tags.length; ++i) {
+		for (var i = 0; i < tags.length; ++i) {
 			$(obj).addTag(tags[i], {
 				focus: false,
 				callback: false


### PR DESCRIPTION
Redeclare `i` each time its uniquely used to prevent undefined behavior when reconstructing the array after a tag is specified for deletion

Closes #44 